### PR TITLE
Use Travis CI's yarn config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
   - env: SUITE="js"
     language: node_js
     node_js: 7
-    sudo: true
   - env: SUITE="python" PYTEST="py.test"
     language: python
     python: 2.7

--- a/ci.sh
+++ b/ci.sh
@@ -11,12 +11,6 @@ go)
 js)
     cd js
     nvm install stable
-
-    # Install Yarn (TODO: use native Travis CI support when available)
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-    sudo apt-get -qq update && sudo apt-get -qq install yarn
-
     yarn global add typescript typescript-formatter mocha
     yarn install
     yarn test

--- a/yarn.lock
+++ b/yarn.lock
@@ -1,0 +1,2 @@
+# This is a placeholder so Travis CI configures the JS build for this project
+# with Yarn.


### PR DESCRIPTION
It magically activates if we have a toplevel yarn.lock file

This is a multi-language project, so we ordinarily wouldn't. However, I guess we
can stick one at the top to pretend we're all JavaScript all the time, and maybe
we'll get Yarn.