### PR TITLE
Improve Ruby decoding performance

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
 LineLength:
   Max: 128
 
+Style/ModuleFunction:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -8,4 +8,5 @@ group :development, :test do
   gem "rake"
   gem "rspec", "~> 3.5"
   gem "rubocop", "0.44.1"
+  gem "benchmark-ips"
 end

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -9,3 +9,17 @@ require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
 task default: %w(spec rubocop)
+
+task :benchmark do
+  require "benchmark/ips"
+  require "zser"
+
+  Benchmark.ips do |b|
+    input = "\xE9\xF4\x81\x80\x80\x80@".dup.force_encoding("BINARY").freeze
+
+    b.report("zsint encode") { Zser::Varint.encode(281_474_976_741_993) }
+    b.report("zsint decode") { Zser::Varint.decode(input) }
+
+    b.compare!
+  end
+end


### PR DESCRIPTION
Eliminates all allocations from the Ruby decoder, and adds a "rake benchmark"
command to measure improvements.

Decode performance is now ~500ns on a 2.3GHz i7.