### PR TITLE
Improve Python decoding performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ matrix:
   - env: SUITE="js"
     language: node_js
     node_js: 7
-  - env: SUITE="python" PYTEST="py.test"
+  - env: SUITE="python"
     language: python
     python: 2.7
-  - env: SUITE="python" PYTEST="pytest"
+  - env: SUITE="python"
     language: python
     python: 3.6
   - env: SUITE="ruby"

--- a/ci.sh
+++ b/ci.sh
@@ -4,7 +4,6 @@ set -e
 
 case $SUITE in
 go)
-    go version
     cd go
     go test -v ./...
     ;;
@@ -17,22 +16,17 @@ js)
     tsfmt --verify $(find {src,test} -name "*.ts")
     ;;
 python)
-    python --version
-    pip --version
     cd python
     export PATH=$HOME/.local/bin:$PATH
     pip install -r requirements.txt --user
-    $PYTEST
+    py.test
     ;;
 ruby)
-    ruby -v
-    bundle --version
     cd ruby
     bundle
     bundle exec rake
     ;;
 rust)
-    rustc --version
     cd rust
     cargo test
     ;;

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
-ipdb==0.10.0
 ipython==4.2.0
 pytest==2.9.2
+pytest-benchmark==3.0.0

--- a/python/tests/test_varint.py
+++ b/python/tests/test_varint.py
@@ -72,3 +72,9 @@ class TestDecode(unittest.TestCase):
     def test_bad_type(self):
         with self.assertRaises(TypeError):
             varint.decode(42)
+
+def test_encode_benchmark(benchmark):
+    benchmark(varint.encode, 281474976741993)
+
+def test_decode_benchmark(benchmark):
+    benchmark(varint.decode, b"\xE9\xF4\x81\x80\x80\x80@")

--- a/python/zser/varint.py
+++ b/python/zser/varint.py
@@ -4,6 +4,24 @@ import struct
 # Maximum value we can encode as a zsuint64
 MAX = (2**64) - 1
 
+# Lookup table for the number of trailing zeroes in a byte
+CTZ_TABLE = [8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             7, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             6, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
+             4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0]
+
 def encode(value):
     """Encode the given integer value as a zsuint64"""
     if not isinstance(value, numbers.Integral):
@@ -44,12 +62,6 @@ def decode(input):
 
     if prefix == 0:
         return struct.unpack("<Q", input[1:9])[0]
-
-    count = 1
-
-    # Count trailing zeroes
-    while prefix & 1 == 0:
-        count += 1
-        prefix >>= 1
-
-    return struct.unpack("<Q", input + b"\0" * (8 - len(input)))[0] >> count
+    else:
+        count = CTZ_TABLE[prefix] + 1
+        return struct.unpack("<Q", input + b"\0" * (8 - len(input)))[0] >> count

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -10,7 +10,7 @@ RuboCop::RakeTask.new
 
 task default: %w(spec rubocop)
 
-task :benchmark do
+task :bench do
   require "benchmark/ips"
   require "zser"
 

--- a/ruby/lib/zser/varint.rb
+++ b/ruby/lib/zser/varint.rb
@@ -7,7 +7,7 @@ module Zser
     # Maximum value we can encode as a zsuint64
     MAX = (2**64) - 1
 
-    # :nodoc:
+    # :nodoc: Lookup table for the number of trailing zeroes in a byte
     CTZ_TABLE = [8, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
                  4, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
                  5, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0,
@@ -51,14 +51,17 @@ module Zser
     def self.decode(input)
       raise TypeError, "input must be a String" unless input.is_a?(String)
       raise ArgumentError, "input cannot be empty" if input.empty?
+
       prefix = input.getbyte(0)
 
-      # 9-byte special case
-      return read_le64(input[1, 8]) if prefix.zero?
-
-      # Count trailing zeroes
-      count = CTZ_TABLE[prefix] + 1
-      read_le64(input[0, count]) >> count
+      if prefix.zero?
+        # 9-byte special case
+        read_le64(input[1, 8])
+      else
+        # Count trailing zeroes
+        count = CTZ_TABLE[prefix] + 1
+        read_le64(input[0, count]) >> count
+      end
     end
 
     # Decode a little endian integer (without allocating memory, unlike pack)


### PR DESCRIPTION
Uses a lookup table to count trailing zeroes. Decode performance is now
~900ns on a 2.3GHz i7.

Adds pytest-benchmark to perform benchmarks.