### PR TITLE
Run ci.sh in the CI environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-script: ./ci.sh
+script: . ./ci.sh
 
 branches:
   only:

--- a/ci.sh
+++ b/ci.sh
@@ -18,7 +18,7 @@ js)
 python)
     cd python
     export PATH=$HOME/.local/bin:$PATH
-    pip install -r requirements.txt --user
+    pip install -r requirements.txt
     py.test
     ;;
 ruby)


### PR DESCRIPTION
We lose all the environment that Travis has set up for us when we spawn a
subshell. This runs the ci.sh script inside the same shell Travis spawns it
with, ensuring we retain the entire environment.