### PR TITLE
js: Use unsigned bitwise right shifts

### DIFF
--- a/js/src/parser.ts
+++ b/js/src/parser.ts
@@ -81,7 +81,7 @@ export class Parser<T> {
     let [value, remaining] = this.parseVarint();
     this.remaining.push(remaining);
 
-    let fieldId = value >> 3;
+    let fieldId = value >>> 3;
     let wiretype = value & 0x7;
 
     return [fieldId, wiretype];

--- a/js/src/varint.ts
+++ b/js/src/varint.ts
@@ -141,7 +141,7 @@ export class Uint64 {
       throw new RangeError("can only shift 32-bits at a time");
     }
 
-    let carry = this.values[0] >> (32 - n) & ((1 << n) - 1);
+    let carry = this.values[0] >>> (32 - n) & ((1 << n) - 1);
     this.values[1] = (this.values[1] << n | carry) & 0xFFFFFFFF;
     this.values[0] = (this.values[0] << n) & 0xFFFFFFFF;
 
@@ -159,8 +159,8 @@ export class Uint64 {
     }
 
     let carry = this.values[1] & ((1 << n) - 1);
-    this.values[1] >>= n;
-    this.values[0] = (this.values[0] >> n) | (carry << (32 - n));
+    this.values[1] >>>= n;
+    this.values[0] = (this.values[0] >>> n) | (carry << (32 - n));
 
     return this;
   }

--- a/js/test/varint.spec.ts
+++ b/js/test/varint.spec.ts
@@ -41,11 +41,6 @@ import { VarintExample } from "./varint_examples";
 
   @test "decodes valid examples"() {
     for (let example of VarintEncode.examples) {
-      // TODO: skip broken example for now. This should get fixed ASAP!
-      if (example.value == 268435455) {
-        continue;
-      }
-
       expect(Varint.decode(example.encoded)[0]).to.eql(example.value);
     }
 
@@ -76,19 +71,22 @@ import { VarintExample } from "./varint_examples";
   }
 
   @test "left bitwise shift"() {
-    /// Low-value example
+    // Low-value example
     expect(Uint64.fromNumber(128).bitwiseLeftShift(1).toInteger()).to.eql(256);
 
-    /// this.exampleNumber >> 1
+    // this.exampleNumber >>> 1
     expect(Uint64.fromNumber(264140488932).bitwiseLeftShift(1).toInteger()).to.eql(this.exampleNumber);
 
-    // this.exampleNumber >> 2
+    // this.exampleNumber >>> 2
     expect(Uint64.fromNumber(132070244466).bitwiseLeftShift(2).toInteger()).to.eql(this.exampleNumber);
   }
 
   @test "right bitwise shift"() {
     expect(Uint64.fromNumber(this.exampleNumber).bitwiseRightShift(1).toInteger()).to.eql(264140488932);
     expect(Uint64.fromNumber(this.exampleNumber).bitwiseRightShift(2).toInteger()).to.eql(132070244466);
+
+    // Ensure values that exceed the signed 32-bit range are correctly handled
+    expect(Uint64.fromNumber(4294967288).bitwiseRightShift(4).toInteger()).to.eql(268435455);
   }
 
   @test "bitwise OR"() {


### PR DESCRIPTION
JavaScript ordinarily converts all numbers to signed 32-bit values before
performing bitwise arithmetic operations.

The Uint64 type used by the varint implementation was broken because it was not
using the unsigned right shift operator. This commit corrects that defect, and
adds a regression test.