### PR TITLE
Fix encoding of certain 9-byte varints

### DIFF
--- a/go/varint.go
+++ b/go/varint.go
@@ -16,7 +16,7 @@ func EncodeVarint(buf []byte, input uint64) int {
 
 	for input >= max {
 		// 9-byte special case
-		if max == 1<<63 {
+		if length == 8 {
 			output.WriteByte(0)
 			binary.Write(output, binary.LittleEndian, input)
 			copy(buf, output.Bytes())

--- a/python/zser/varint.py
+++ b/python/zser/varint.py
@@ -44,7 +44,7 @@ def encode(value):
 
     while value >= max:
         # 9-byte special case
-        if max == 1 << 63:
+        if length == 8:
             return struct.pack("<BQ", 0, value)
         result <<= 1
         max <<= 7

--- a/ruby/lib/zser/varint.rb
+++ b/ruby/lib/zser/varint.rb
@@ -44,7 +44,7 @@ module Zser
 
       while value >= max
         # 9-byte special case
-        return [0, value].pack("CQ<") if max == 1 << 63
+        return [0, value].pack("CQ<") if length == 8
 
         result <<= 1
         max <<= 7

--- a/rust/src/varint.rs
+++ b/rust/src/varint.rs
@@ -14,7 +14,7 @@ pub fn encode(value: u64, out: &mut [u8]) -> usize {
 
     while value >= max {
         // 9-byte special case
-        if max == 1 << 63 {
+        if length == 8 {
             out[0] = 0;
             LittleEndian::write_u64(&mut out[1..9], value);
             return 9;

--- a/vectors/varint.tjson
+++ b/vectors/varint.tjson
@@ -65,6 +65,14 @@
             "encoded:d16": "8000000000000002"
         },
         {
+            "value:u": "9223372036854775807",
+            "encoded:d16": "00ffffffffffffff7f"
+        },
+        {
+            "value:u": "9223372036854775808",
+            "encoded:d16": "000000000000000080"
+        },
+        {
             "value:u": "18446744073709551614",
             "encoded:d16": "00feffffffffffffff"
         },


### PR DESCRIPTION
The condition used to gate the 9-byte special case serialization was broken
across several implementations.

This fixes the problems, and adds a test case to vectors/varint.tjson