### PR TITLE
rust: cargo fuzz + corrupted varint handling

### DIFF
--- a/rust/fuzz/.gitignore
+++ b/rust/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/rust/fuzz/Cargo.lock
+++ b/rust/fuzz/Cargo.lock
@@ -1,0 +1,44 @@
+[root]
+name = "zser-fuzz"
+version = "0.0.1"
+dependencies = [
+ "libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)",
+ "zser 0.0.1",
+]
+
+[[package]]
+name = "arbitrary"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "gcc"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.1.0"
+source = "git+https://github.com/rust-fuzz/libfuzzer-sys.git#bcaa8e1c4ee37fb5a1667da297d7aa16e257399c"
+dependencies = [
+ "arbitrary 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zser"
+version = "0.0.1"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum arbitrary 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "baa5f4eaa3a3603a0d83861560ab55dfa6c8dd094b05604e5d006b41ffaeb1d3"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
+"checksum gcc 0.3.50 (registry+https://github.com/rust-lang/crates.io-index)" = "5f837c392f2ea61cb1576eac188653df828c861b7137d74ea4a5caa89621f9e6"
+"checksum libfuzzer-sys 0.1.0 (git+https://github.com/rust-fuzz/libfuzzer-sys.git)" = "<none>"

--- a/rust/fuzz/Cargo.toml
+++ b/rust/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+
+[package]
+name = "zser-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.zser]
+path = ".."
+
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "varint_fuzzer"
+path = "fuzzers/varint_fuzzer.rs"

--- a/rust/fuzz/fuzzers/varint_fuzzer.rs
+++ b/rust/fuzz/fuzzers/varint_fuzzer.rs
@@ -1,0 +1,21 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate zser;
+
+use zser::varint;
+
+fuzz_target!(|input: &[u8]| {
+    let mut input_ref = &input[..];
+
+    let value = match varint::decode(&mut input_ref) {
+        Ok(v) => v,
+        Err(_) => return
+    };
+
+    let mut output = [0u8; 9];
+    let len = varint::encode(value, &mut output);
+
+    if &input[..len] != &output[..len] {
+        panic!("input and output do not match: input: {:?}, output: {:?}, len: {:?}", input, output, len);
+    }
+});

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,16 +1,16 @@
 //! errors.rs: error types used by this crate
 
-use core::fmt::{self, Debug, Display};
-use core::result;
-
-#[cfg(feature = "std")]
-use std::error;
 
 #[cfg(not(feature = "std"))]
 use collections::boxed::Box;
 
 #[cfg(not(feature = "std"))]
 use collections::string::String;
+use core::fmt::{self, Debug, Display};
+use core::result;
+
+#[cfg(feature = "std")]
+use std::error;
 
 /// Errors which can occur when serializing or deserializing zser messages
 pub struct Error {
@@ -38,6 +38,9 @@ pub enum ErrorKind {
     /// Expected more data in message
     TruncatedMessage(String),
 
+    /// Corruption detected in message
+    CorruptedMessage(String),
+
     /// Message encoded with an unknown wiretype
     UnknownWiretype(u64),
 
@@ -55,6 +58,7 @@ impl Display for ErrorKind {
                 write!(f, "max nested message depth of {} exceeded", max)
             }
             ErrorKind::TruncatedMessage(ref msg) => write!(f, "message truncated: {}", msg),
+            ErrorKind::CorruptedMessage(ref msg) => write!(f, "message corrupted: {}", msg),
             ErrorKind::UnknownWiretype(wiretype) => write!(f, "unknown wiretype: {}", wiretype),
             ErrorKind::UnconsumedMessages(count) => {
                 write!(f, "unconsumed messages in buffer: {} messages", count)
@@ -70,6 +74,7 @@ impl error::Error for Error {
             ErrorKind::OversizedMessage(_) => "message too long",
             ErrorKind::MaxDepthExceeded(_) => "maximum number of nested messages exceeded",
             ErrorKind::TruncatedMessage(_) => "message truncated",
+            ErrorKind::CorruptedMessage(_) => "message corrupted",
             ErrorKind::UnknownWiretype(_) => "unknown wiretype",
             ErrorKind::UnconsumedMessages(_) => "unconsumed messages in buffer",
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -15,7 +15,8 @@
 extern crate byteorder;
 
 #[cfg(not(feature = "std"))]
-#[macro_use] extern crate collections;
+#[macro_use]
+extern crate collections;
 
 #[cfg(feature = "std")]
 extern crate core;

--- a/rust/src/value.rs
+++ b/rust/src/value.rs
@@ -1,13 +1,13 @@
 //! The Value enum: a loosely typed way of representing zser messages.
 
-#[cfg(feature = "std")]
-pub use std::collections::HashMap;
 
 #[cfg(not(feature = "std"))]
 pub use collections::btree_map::BTreeMap;
 
 #[cfg(not(feature = "std"))]
 use collections::vec::Vec;
+#[cfg(feature = "std")]
+pub use std::collections::HashMap;
 
 /// Integer ID -> Value mapping with `hashDoS`-resistant `HashMap` on std
 #[cfg(feature = "std")]


### PR DESCRIPTION
This adds cargo fuzz, a libfuzzer-based fuzz testing tool, to the Rust
implementation.

Uncovered in the process of fuzz testing was a class of inputs which would
decode as varints even though they shouldn't (i.e. garbage inputs that would
decode in a non-roundtrippable manner, because the length prefix encoded an
integer with e.g. a large zero component)

A check has been added for this class of inputs in the Rust implementation. In a
subsequent commit these cases will be added to the test vectors, and the same
check added to other language implementations.