### PR TITLE
Reject invalid oversized varints

### DIFF
--- a/js/test/varint.spec.ts
+++ b/js/test/varint.spec.ts
@@ -12,6 +12,10 @@ import { VarintExample } from "./varint_examples";
 
   @test "encodes valid examples"() {
     for (let example of VarintEncode.examples) {
+      if (!example.success) {
+        continue;
+      }
+
       expect(Varint.encode(example.value)).to.eql(example.encoded);
     }
 
@@ -41,7 +45,11 @@ import { VarintExample } from "./varint_examples";
 
   @test "decodes valid examples"() {
     for (let example of VarintEncode.examples) {
-      expect(Varint.decode(example.encoded)[0]).to.eql(example.value);
+      if (example.success) {
+        expect(Varint.decode(example.encoded)[0]).to.eql(example.value);
+      } else {
+        expect(() => Varint.decode(example.encoded)).to.throw(Error);
+      }
     }
 
     // Serialization of Varint.MAX

--- a/js/test/varint_examples.ts
+++ b/js/test/varint_examples.ts
@@ -36,5 +36,6 @@ export class VarintExample {
   constructor(
     public readonly value: number,
     public readonly encoded: Uint8Array,
+    public readonly success: boolean
   ) { }
 }

--- a/python/tests/support/varint_examples.py
+++ b/python/tests/support/varint_examples.py
@@ -4,7 +4,7 @@ import binascii
 import json
 from collections import namedtuple
 
-VarintExample = namedtuple("VarintExample", ["value", "encoded"])
+VarintExample = namedtuple("VarintExample", ["value", "encoded", "success"])
 
 
 def load():
@@ -23,9 +23,15 @@ def load_from_file(filename):
 
     result = []
     for example in examples:
+        value = None
+        success = example[u"success:b"]
+        if success:
+            value = int(example[u"value:u"])
+
         result.append(VarintExample(
-            value=int(example[u"value:u"]),
+            value=value,
             encoded=binascii.unhexlify(example[u"encoded:d16"]),
+            success=success
         ))
 
     return result

--- a/python/tests/test_varint.py
+++ b/python/tests/test_varint.py
@@ -9,14 +9,15 @@ Tests for the zser `varint` module: prefixed variable-sized integers
 
 import unittest
 from zser import varint
-from zser.exceptions import TruncatedMessageError
+from zser.exceptions import TruncatedMessageError, ParseError
 
 from .support import varint_examples
 
 class TestEncode(unittest.TestCase):
     def test_valid_examples(self):
         for example in varint_examples.load():
-            self.assertEqual(varint.encode(example.value), example.encoded)
+            if example.success:
+                self.assertEqual(varint.encode(example.value), example.encoded)
 
     def test_non_integer_param(self):
         with self.assertRaises(TypeError):
@@ -34,7 +35,11 @@ class TestEncode(unittest.TestCase):
 class TestDecode(unittest.TestCase):
     def test_valid_examples(self):
         for example in varint_examples.load():
-            self.assertEqual(varint.decode(example.encoded), (example.value, b""))
+            if example.success:
+                self.assertEqual(varint.decode(example.encoded), (example.value, b""))
+            else:
+                with self.assertRaises(ParseError):
+                    varint.decode(example.encoded)
 
     def test_empty_input(self):
         with self.assertRaises(TruncatedMessageError):

--- a/python/zser/varint.py
+++ b/python/zser/varint.py
@@ -1,6 +1,6 @@
 """varint.py: Little Endian 64-bit Unsigned Prefix Varints"""
 
-from .exceptions import TruncatedMessageError
+from .exceptions import ParseError, TruncatedMessageError
 import numbers
 import struct
 import sys
@@ -78,5 +78,8 @@ def decode(encoded):
         decoded = struct.unpack("<Q", encoded[1:9])[0]
     else:
         decoded = struct.unpack("<Q", encoded[:length] + b"\0" * (8 - length))[0] >> length
+
+    if length > 1 and decoded < (1 << (7 * (length - 1))):
+        raise ParseError("malformed varint")
 
     return decoded, encoded[length:]

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -19,7 +19,7 @@ Style/StringLiterals:
 #
 
 Metrics/AbcSize:
-  Max: 25
+  Max: 30
 
 Metrics/BlockLength:
   Enabled: false

--- a/ruby/lib/zser/exceptions.rb
+++ b/ruby/lib/zser/exceptions.rb
@@ -11,7 +11,7 @@ module Zser
   EncodingError = Class.new(ParseError)
 
   # Unexpected end of input
-  EOFError = Class.new(ParseError)
+  TruncatedMessageError = Class.new(ParseError)
 
   # Message is larger than our maximum configured size
   OversizeMessageError = Class.new(ParseError)

--- a/ruby/lib/zser/parser.rb
+++ b/ruby/lib/zser/parser.rb
@@ -68,7 +68,7 @@ module Zser
     # Parse a data type stored with a length prefix
     def parse_length_prefixed_data
       length, remaining = Zser::Varint.decode(@remaining.pop)
-      raise EOFError, "not enough bytes remaining in input" if remaining.bytesize < length
+      raise TruncatedMessageError, "not enough bytes remaining in input" if remaining.bytesize < length
       data = remaining.byteslice(0, length)
       @remaining << remaining.byteslice(length, remaining.bytesize - length)
       data

--- a/ruby/spec/support/varint_examples.rb
+++ b/ruby/spec/support/varint_examples.rb
@@ -3,7 +3,7 @@
 require "tjson"
 
 class VarintExample
-  attr_reader :value, :encoded
+  attr_reader :value, :encoded, :success
 
   # Error parsing the example file
   ParseError = Class.new(StandardError)
@@ -19,7 +19,8 @@ class VarintExample
   end
 
   def initialize(attrs)
-    @value = attrs.fetch("value")
+    @success = attrs.fetch("success")
+    @value = attrs.fetch("value") if @success
     @encoded = attrs.fetch("encoded")
   end
 end

--- a/ruby/spec/zser/varint_spec.rb
+++ b/ruby/spec/zser/varint_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Zser::Varint do
     context "varint.tjson examples" do
       it "encodes examples successfully" do
         VarintExample.load_file.each do |ex|
+          next unless ex.success
           expect(described_class.encode(ex.value)).to eq ex.encoded
         end
       end
@@ -27,7 +28,11 @@ RSpec.describe Zser::Varint do
   describe ".decode" do
     it "decodes examples successfully" do
       VarintExample.load_file.each do |ex|
-        expect(described_class.decode(ex.encoded)).to eq [ex.value, ""]
+        if ex.success
+          expect(described_class.decode(ex.encoded)).to eq [ex.value, ""]
+        else
+          expect { described_class.decode(ex.encoded) }.to raise_error Zser::ParseError
+        end
       end
     end
 
@@ -39,9 +44,9 @@ RSpec.describe Zser::Varint do
       expect { described_class.decode(42) }.to raise_error TypeError
     end
 
-    it "raises Zser::EOFError if input is truncated" do
-      expect { described_class.decode("\x02") }.to raise_error Zser::EOFError
-      expect { described_class.decode("\x00\xFF") }.to raise_error Zser::EOFError
+    it "raises Zser::TruncatedMessageError if input is truncated" do
+      expect { described_class.decode("\x02") }.to raise_error Zser::TruncatedMessageError
+      expect { described_class.decode("\x00\xFF") }.to raise_error Zser::TruncatedMessageError
     end
   end
 end

--- a/rust/src/varint.rs
+++ b/rust/src/varint.rs
@@ -48,7 +48,7 @@ pub fn decode(input: &mut &[u8]) -> Result<u64> {
             let result = LittleEndian::read_u64(&bytes[1..9]);
 
             if result < (1 << 56) {
-                return Err(ErrorKind::CorruptedMessage("malformatted varint".to_string()).into());
+                return Err(ErrorKind::CorruptedMessage("malformed varint".to_string()).into());
             }
 
             *input = &bytes[9..];
@@ -67,7 +67,7 @@ pub fn decode(input: &mut &[u8]) -> Result<u64> {
     let result = LittleEndian::read_uint(bytes, length) >> length;
 
     if length > 1 && result < (1 << (7 * (length - 1))) {
-        return Err(ErrorKind::CorruptedMessage("malformatted varint".to_string()).into());
+        return Err(ErrorKind::CorruptedMessage("malformed varint".to_string()).into());
     }
 
     *input = &bytes[length..];

--- a/rust/tests/lib.rs
+++ b/rust/tests/lib.rs
@@ -37,7 +37,11 @@ fn varint_encode() {
     let mut output = [0u8; 9];
 
     for example in examples {
-        let len = varint::encode(example.value, &mut output);
+        if !example.success {
+            continue;
+        }
+
+        let len = varint::encode(example.value.expect("integer value"), &mut output);
         assert_eq!(&output[..len], &example.encoded[..]);
     }
 }
@@ -48,7 +52,14 @@ fn varint_decode() {
 
     for example in examples {
         let mut encoded_ref = &example.encoded[..];
-        assert_eq!(varint::decode(&mut encoded_ref).unwrap(), example.value);
-        assert_eq!(encoded_ref, b"");
+
+        if example.success {
+            assert_eq!(varint::decode(&mut encoded_ref).unwrap(),
+                       example.value.expect("integer value"));
+            assert_eq!(encoded_ref, b"");
+        } else if varint::decode(&mut encoded_ref).is_ok() {
+            panic!("expected error but example parsed successfully: {:?}",
+                   example.encoded);
+        }
     }
 }

--- a/rust/tests/varint_examples.rs
+++ b/rust/tests/varint_examples.rs
@@ -12,8 +12,9 @@ use std::path::Path;
 // TODO: switch to the tjson crate (based on serde)
 #[derive(Debug)]
 pub struct VarintExample {
-    pub value: u64,
+    pub value: Option<u64>,
     pub encoded: Vec<u8>,
+    pub success: bool,
 }
 
 /// Load examples from varint.tjson
@@ -37,18 +38,27 @@ pub fn load_from_file(path: &Path) -> Vec<VarintExample> {
     examples
         .into_iter()
         .map(|ex| {
+            let success = ex["success:b"].as_bool().expect("success boolean");
+
+            let value = if success {
+                Some(ex["value:u"]
+                         .as_str()
+                         .expect("value string")
+                         .parse()
+                         .expect("unsigned integer value"))
+            } else {
+                None
+            };
+
             VarintExample {
-                value: ex["value:u"]
-                    .as_str()
-                    .expect("string data")
-                    .parse()
-                    .expect("unsigned integer value"),
+                value: value,
                 encoded: HEXLOWER
                     .decode(ex["encoded:d16"]
                                 .as_str()
                                 .expect("encoded example")
                                 .as_bytes())
                     .expect("hex encoded"),
+                success: success,
             }
         })
         .collect()

--- a/vectors/varint.tjson
+++ b/vectors/varint.tjson
@@ -2,83 +2,119 @@
     "examples:A<O>": [
         {
             "value:u": "0",
-            "encoded:d16": "01"
+            "encoded:d16": "01",
+            "success:b": true
         },
         {
             "value:u": "1",
-            "encoded:d16": "03"
+            "encoded:d16": "03",
+            "success:b": true
         },
         {
             "value:u": "127",
-            "encoded:d16": "ff"
+            "encoded:d16": "ff",
+            "success:b": true
         },
         {
             "value:u": "128",
-            "encoded:d16": "0202"
+            "encoded:d16": "0202",
+            "success:b": true
         },
         {
             "value:u": "16383",
-            "encoded:d16": "feff"
+            "encoded:d16": "feff",
+            "success:b": true
         },
         {
             "value:u": "16384",
-            "encoded:d16": "040002"
+            "encoded:d16": "040002",
+            "success:b": true
         },
         {
             "value:u": "2097151",
-            "encoded:d16": "fcffff"
+            "encoded:d16": "fcffff",
+            "success:b": true
         },
         {
             "value:u": "2097152",
-            "encoded:d16": "08000002"
+            "encoded:d16": "08000002",
+            "success:b": true
         },
         {
             "value:u": "268435455",
-            "encoded:d16": "f8ffffff"
+            "encoded:d16": "f8ffffff",
+            "success:b": true
         },
         {
             "value:u": "268435456",
-            "encoded:d16": "1000000002"
+            "encoded:d16": "1000000002",
+            "success:b": true
         },
         {
             "value:u": "34359738367",
-            "encoded:d16": "f0ffffffff"
+            "encoded:d16": "f0ffffffff",
+            "success:b": true
         },
         {
             "value:u": "34359738368",
-            "encoded:d16": "200000000002"
+            "encoded:d16": "200000000002",
+            "success:b": true
         },
         {
             "value:u": "4398046511103",
-            "encoded:d16": "e0ffffffffff"
+            "encoded:d16": "e0ffffffffff",
+            "success:b": true
         },
         {
             "value:u": "4398046511104",
-            "encoded:d16": "40000000000002"
+            "encoded:d16": "40000000000002",
+            "success:b": true
         },
         {
             "value:u": "562949953421311",
-            "encoded:d16": "c0ffffffffffff"
+            "encoded:d16": "c0ffffffffffff",
+            "success:b": true
         },
         {
             "value:u": "562949953421312",
-            "encoded:d16": "8000000000000002"
+            "encoded:d16": "8000000000000002",
+            "success:b": true
         },
         {
             "value:u": "9223372036854775807",
-            "encoded:d16": "00ffffffffffffff7f"
+            "encoded:d16": "00ffffffffffffff7f",
+            "success:b": true
         },
         {
             "value:u": "9223372036854775808",
-            "encoded:d16": "000000000000000080"
+            "encoded:d16": "000000000000000080",
+            "success:b": true
         },
         {
             "value:u": "18446744073709551614",
-            "encoded:d16": "00feffffffffffffff"
+            "encoded:d16": "00feffffffffffffff",
+            "success:b": true
         },
         {
             "value:u": "18446744073709551615",
-            "encoded:d16": "00ffffffffffffffff"
+            "encoded:d16": "00ffffffffffffffff",
+            "success:b": true
+        },
+        {
+            "encoded:d16": "00",
+            "success:b": false
+        },
+        {
+            "encoded:d16": "000000000000000000",
+            "success:b": false
+        },
+        {
+            "encoded:d16": "00ff00000000000000",
+            "success:b": false
+        },
+        {
+            "encoded:d16": "aa00",
+            "success:b": false
         }
     ]
 }


### PR DESCRIPTION
Naive varint implementations can potentially decode certain varint
serializations that are longer than they need to be.

In hopes of avoiding an ambiguity in the format, this adds checks and test cases
to ensure that all implementations reject these invalid serializations.